### PR TITLE
feat: Enable project creation and fetching via API

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -39,6 +39,22 @@ app.post('/api/compile', (req, res) => {
   });
 });
 
+app.get('/api/projects', (req, res) => {
+  const projectsPath = path.join(__dirname, '..');
+  fs.readdir(projectsPath, { withFileTypes: true }, (err, files) => {
+    if (err) {
+      return res.status(500).json({ message: 'Failed to read projects directory.' });
+    }
+
+    const projects = files
+      .filter(dirent => dirent.isDirectory())
+      .filter(dirent => fs.existsSync(path.join(projectsPath, dirent.name, 'package.json')))
+      .map(dirent => dirent.name);
+
+    res.json(projects);
+  });
+});
+
 app.post('/api/projects', (req, res) => {
   const { projectName } = req.body;
 

--- a/server/server/package-lock.json
+++ b/server/server/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/components/ProjectSelection.tsx
+++ b/src/components/ProjectSelection.tsx
@@ -1,9 +1,13 @@
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { AppContext, AppContextType } from '../contexts/AppContext';
 
 const ProjectSelection = () => {
-  const { createProject } = useContext(AppContext) as AppContextType;
+  const { projects, fetchProjects, createProject } = useContext(AppContext) as AppContextType;
   const [projectName, setProjectName] = useState('');
+
+  useEffect(() => {
+    fetchProjects();
+  }, [fetchProjects]);
 
   const handleCreateProject = () => {
     if (projectName.trim()) {
@@ -14,21 +18,33 @@ const ProjectSelection = () => {
   return (
     <div className="flex flex-col items-center justify-center h-screen bg-gray-800 text-white">
       <h1 className="text-4xl font-bold mb-8">Game Engine</h1>
-      <div className="bg-gray-700 p-8 rounded-lg">
+      <div className="bg-gray-700 p-8 rounded-lg w-1/3">
         <h2 className="text-2xl font-bold mb-4">Create New Project</h2>
-        <input
-          type="text"
-          value={projectName}
-          onChange={(e) => setProjectName(e.target.value)}
-          className="bg-gray-800 w-full p-2 mb-4"
-          placeholder="Project name"
-        />
-        <button
-          onClick={handleCreateProject}
-          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded w-full"
-        >
-          Create Project
-        </button>
+        <div className="flex">
+          <input
+            type="text"
+            value={projectName}
+            onChange={(e) => setProjectName(e.target.value)}
+            className="bg-gray-800 w-full p-2 mb-4"
+            placeholder="Project name"
+          />
+          <button
+            onClick={handleCreateProject}
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2"
+          >
+            Create
+          </button>
+        </div>
+        <div>
+          <h2 className="text-2xl font-bold mb-4">Select Project</h2>
+          <ul>
+            {projects.map((project) => (
+              <li key={project} className="p-2 hover:bg-gray-600 cursor-pointer">
+                {project}
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
This commit introduces the functionality to create new projects and fetch existing ones through a backend API.

- Implemented a `GET /api/projects` endpoint on the server to retrieve a list of existing projects.
- Updated the `createProject` function in the frontend to send a `POST` request to the `/api/projects` endpoint.
- Modified the `ProjectSelection` component to display the list of fetched projects and allow you to create a new project.