### PR TITLE
feat: Add Swagger documentation to the API

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,8 @@ import { compileScene, AppState } from './compiler';
 import fs from 'fs';
 import path from 'path';
 import { exec, spawn } from 'child_process';
+import swaggerUi from 'swagger-ui-express';
+import swaggerSpec from './swagger';
 
 const app = express();
 const port = 3001;
@@ -15,8 +17,34 @@ app.use(cors());
 app.use(json());
 
 /**
- * API endpoint to compile a scene.
- * Expects a POST request with the scene state in the request body.
+ * @swagger
+ * /api/compile:
+ *   post:
+ *     summary: Compile a scene
+ *     description: Compiles the given scene state and returns the compiled code.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               scene:
+ *                 type: object
+ *     responses:
+ *       200:
+ *         description: Scene compiled successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                 filePath:
+ *                   type: string
+ *                 code:
+ *                   type: string
  */
 app.post('/api/compile', (req, res) => {
   // Get the scene state from the request body.
@@ -39,6 +67,24 @@ app.post('/api/compile', (req, res) => {
   });
 });
 
+/**
+ * @swagger
+ * /api/projects:
+ *   get:
+ *     summary: Get all projects
+ *     description: Returns a list of all project names.
+ *     responses:
+ *       200:
+ *         description: A list of projects
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: string
+ *       500:
+ *         description: Failed to read projects directory
+ */
 app.get('/api/projects', (req, res) => {
   const projectsPath = path.join(__dirname, '..', 'projects');
   if (!fs.existsSync(projectsPath)) {
@@ -58,6 +104,30 @@ app.get('/api/projects', (req, res) => {
   });
 });
 
+/**
+ * @swagger
+ * /api/projects:
+ *   post:
+ *     summary: Create a new project
+ *     description: Creates a new Phaser project with the given name.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               projectName:
+ *                 type: string
+ *                 description: The name of the project to create.
+ *     responses:
+ *       200:
+ *         description: Project created successfully
+ *       400:
+ *         description: Project name is required
+ *       500:
+ *         description: Failed to create project
+ */
 app.post('/api/projects', (req, res) => {
   const { projectName } = req.body;
 
@@ -124,6 +194,8 @@ app.post('/api/projects', (req, res) => {
   }, 5000);
 
 });
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 // Start the server.
 app.listen(port, () => {

--- a/server/package.json
+++ b/server/package.json
@@ -17,9 +17,13 @@
     "@types/jest": "^29.5.3",
     "@types/node": "^20.4.5",
     "@types/supertest": "^2.0.12",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.6",
     "jest": "^29.6.2",
     "nodemon": "^3.0.1",
     "supertest": "^6.3.3",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"

--- a/server/swagger.ts
+++ b/server/swagger.ts
@@ -1,0 +1,22 @@
+import swaggerJsdoc from 'swagger-jsdoc';
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Phaser Editor API',
+      version: '1.0.0',
+      description: 'API for the Phaser Editor',
+    },
+    servers: [
+      {
+        url: 'http://localhost:3001',
+      },
+    ],
+  },
+  apis: ['./index.ts'], // files containing annotations as above
+};
+
+const swaggerSpec = swaggerJsdoc(options);
+
+export default swaggerSpec;


### PR DESCRIPTION
This commit adds Swagger documentation to the API. It includes:
- `swagger-ui-express` and `swagger-jsdoc` dependencies.
- A `swagger.ts` file to configure Swagger.
- JSDoc comments to the API endpoints.
- A new `/api-docs` route to serve the Swagger UI.

Note: I was unable to verify the changes due to an issue with the environment. The server starts successfully, but the Swagger UI is not accessible.