### PR TITLE
feat: Load project into editor on click

### DIFF
--- a/src/components/ProjectSelection.tsx
+++ b/src/components/ProjectSelection.tsx
@@ -2,7 +2,7 @@ import { useContext, useEffect, useState } from 'react';
 import { AppContext, AppContextType } from '../contexts/AppContext';
 
 const ProjectSelection = () => {
-  const { projects, fetchProjects, createProject } = useContext(AppContext) as AppContextType;
+  const { projects, fetchProjects, createProject, selectProject } = useContext(AppContext) as AppContextType;
   const [projectName, setProjectName] = useState('');
 
   useEffect(() => {
@@ -39,7 +39,11 @@ const ProjectSelection = () => {
           <h2 className="text-2xl font-bold mb-4">Select Project</h2>
           <ul>
             {projects.map((project) => (
-              <li key={project} className="p-2 hover:bg-gray-600 cursor-pointer">
+              <li
+                key={project}
+                className="p-2 hover:bg-gray-600 cursor-pointer"
+                onClick={() => selectProject(project)}
+              >
                 {project}
               </li>
             ))}

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -40,6 +40,7 @@ export interface AppContextType extends AppState {
   addScriptToGameObject: (id: number, script: string) => void;
   addScript: (name: string) => void;
   createProject: (name: string) => void;
+  selectProject: (name: string) => void;
 }
 
 // Create the React context.
@@ -92,7 +93,17 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
     }
   };
 
-  const addGameObject = (name: string) => {
+    const selectProject = (name: string) => {
+      setState((prevState) => ({
+        ...prevState,
+        project: { name },
+        gameObjects: [],
+        selectedObjectId: null,
+        scripts: [],
+      }));
+    };
+
+    const addGameObject = (name:string) => {
     setState((prevState) => ({
       ...prevState,
       gameObjects: [
@@ -142,6 +153,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
         addScriptToGameObject,
         addScript,
         createProject,
+          selectProject,
       }}
     >
       {children}


### PR DESCRIPTION
This commit introduces the functionality to load a project into the editor when it is clicked on the project selection screen.

- Added a `selectProject` function to the `AppContext` to manage the currently selected project.
- The `ProjectSelection` component now uses this function to handle clicks on project list items, triggering the loading of the selected project.
- This provides a more intuitive user experience, allowing you to easily switch between projects.