### PR TITLE
feat: Dockerize Cypress tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use the official Cypress image with browsers and Node.js
+FROM cypress/browsers:node-22.17.1-chrome-129.0.6647.137-1-ff-129.0-edge-129.0.2792.81-1
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json
+COPY package.json package-lock.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port for the dev server
+EXPOSE 5173

--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ This project includes tests for both the backend and frontend.
     ```bash
     npm run cypress:run
     ```
+
+## Running Tests with Docker
+
+This project is configured to run the Cypress tests in a Docker container. This ensures a consistent testing environment.
+
+1.  **Build and run the tests:**
+    ```bash
+    docker-compose up --build
+    ```
+    This command will build the Docker image, start the web server, and run the Cypress tests. The `--build` flag is only necessary the first time you run the command, or if you have made changes to the `Dockerfile` or the application code.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  web:
+    build: .
+    ports:
+      - "5173:5173"
+    command: npm run dev
+  cypress:
+    build: .
+    depends_on:
+      - web
+    command: npm run cypress:run
+    environment:
+      - CYPRESS_baseUrl=http://web:5173


### PR DESCRIPTION
This commit dockerizes the Cypress tests to provide a consistent testing environment and fix failures related to missing system dependencies like Xvfb.

- Adds a `Dockerfile` that uses the official Cypress browsers image.
- Adds a `docker-compose.yml` to orchestrate the running of the app and the tests.
- Updates the `README.md` with instructions on how to run the tests using Docker.