### PR TITLE
feat: Create .scene file for default game

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -160,6 +160,17 @@ app.post('/api/projects', (req, res) => {
       return res.status(500).json({ message: `Failed to create project. Exit code: ${code}` });
     }
 
+    // Create a default .scene file
+    const sceneDir = path.join(projectsPath, projectName, 'src', 'game', 'scenes');
+    fs.mkdirSync(sceneDir, { recursive: true });
+    const sceneFilePath = path.join(sceneDir, 'Game.scene');
+    const defaultSceneContent = {
+      gameObjects: [],
+      selectedObjectId: null,
+      scripts: [],
+    };
+    fs.writeFileSync(sceneFilePath, JSON.stringify(defaultSceneContent, null, 2));
+
     res.json({ message: `Project ${projectName} created successfully!` });
   });
 


### PR DESCRIPTION
When a new project is created, a default `.scene` file is now created for the main `Game.ts`.

This allows you to immediately start using the scene editor without having to manually create a scene file.

The default scene is created at `projects/<projectName>/src/game/scenes/Game.scene` and contains an empty `AppState`.