### PR TITLE
Refactor: Fix scene/asset fetching and update UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import InspectorPanel from './components/InspectorPanel';
 import ProjectPanel from './components/ProjectPanel';
 import { AppContext, AppContextType } from './contexts/AppContext';
 import ProjectSelection from './components/ProjectSelection';
+import SceneToolbar from './components/SceneToolbar';
+import AssetsToolbar from './components/AssetsToolbar';
 
 function App() {
   const { project } = useContext(AppContext) as AppContextType;
@@ -21,6 +23,7 @@ function App() {
         <div className="w-1/5 min-w-[200px] flex flex-col">
           <HierarchyPanel />
           <ProjectPanel />
+          <SceneToolbar />
         </div>
         <div className="w-3/5">
           <SceneView />
@@ -29,6 +32,7 @@ function App() {
           <InspectorPanel />
         </div>
       </div>
+      <AssetsToolbar />
     </div>
   );
 }

--- a/src/components/AssetsToolbar.tsx
+++ b/src/components/AssetsToolbar.tsx
@@ -7,9 +7,9 @@ const AssetsToolbar = () => {
 
   useEffect(() => {
     if (project) {
-      fetch(`http://localhost:3001/api/projects/${project}/assets`)
+      fetch(`http://localhost:3001/api/projects/${project.name}/assets`)
         .then((res) => res.json())
-        .then((data) => setAssets(data))
+        .then((data) => setAssets(data.assets))
         .catch((err) => console.error('Failed to fetch assets:', err));
     }
   }, [project]);
@@ -18,9 +18,8 @@ const AssetsToolbar = () => {
     <div className="bg-gray-800 p-2">
       <h2 className="text-lg font-bold mb-2">Assets</h2>
       <ul>
-        {assets.map((asset) => (
-          <li key={asset}>{asset}</li>
-        ))}
+        {assets &&
+          assets.map((asset) => <li key={asset}>{asset}</li>)}
       </ul>
     </div>
   );

--- a/src/components/SceneToolbar.tsx
+++ b/src/components/SceneToolbar.tsx
@@ -7,9 +7,9 @@ const SceneToolbar = () => {
 
   useEffect(() => {
     if (project) {
-      fetch(`http://localhost:3001/api/projects/${project}/scenes`)
+      fetch(`http://localhost:3001/api/projects/${project.name}/scenes`)
         .then((res) => res.json())
-        .then((data) => setScenes(data))
+        .then((data) => setScenes(data.scenes))
         .catch((err) => console.error('Failed to fetch scenes:', err));
     }
   }, [project]);
@@ -18,9 +18,8 @@ const SceneToolbar = () => {
     <div className="bg-gray-800 p-2">
       <h2 className="text-lg font-bold mb-2">Scenes</h2>
       <ul>
-        {scenes.map((scene) => (
-          <li key={scene}>{scene}</li>
-        ))}
+        {scenes &&
+          scenes.map((scene) => <li key={scene}>{scene}</li>)}
       </ul>
     </div>
   );

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,8 +1,6 @@
 import { useContext, useState } from 'react';
 import { AppContext, AppContextType } from '../contexts/AppContext';
 import Modal from './Modal';
-import SceneToolbar from './SceneToolbar';
-import AssetsToolbar from './AssetsToolbar';
 
 /**
  * The toolbar component at the top of the editor.
@@ -12,8 +10,6 @@ const Toolbar = () => {
   const appState = useContext(AppContext) as AppContextType;
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [compiledCode, setCompiledCode] = useState('');
-  const [showSceneToolbar, setShowSceneToolbar] = useState(false);
-  const [showAssetsToolbar, setShowAssetsToolbar] = useState(false);
 
   /**
    * Handles the "Build Project" button click.
@@ -41,26 +37,12 @@ const Toolbar = () => {
     <>
       <div className="bg-gray-700 p-2 flex gap-2" role="toolbar">
         <button
-          onClick={() => setShowSceneToolbar(!showSceneToolbar)}
-          className="bg-gray-600 hover:bg-gray-500 text-white font-bold py-2 px-4 rounded"
-        >
-          Scene
-        </button>
-        <button
-          onClick={() => setShowAssetsToolbar(!showAssetsToolbar)}
-          className="bg-gray-600 hover:bg-gray-500 text-white font-bold py-2 px-4 rounded"
-        >
-          Assets
-        </button>
-        <button
           onClick={handleBuild}
           className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
         >
           Build Project
         </button>
       </div>
-      {showSceneToolbar && <SceneToolbar />}
-      {showAssetsToolbar && <AssetsToolbar />}
       <Modal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}


### PR DESCRIPTION
This commit addresses two main issues:

1.  **Bugfix:** The API calls to fetch scenes and assets were failing because they were using the entire project object in the URL instead of the project name. This has been fixed by using `project.name` in the fetch URLs in `SceneToolbar.tsx` and `AssetsToolbar.tsx`. Added checks to prevent crashes if the API returns non-array data.

2.  **UI Refactor:** The `SceneToolbar` and `AssetsToolbar` components have been moved from the main toolbar into dedicated panels. The `SceneToolbar` is now in the left sidebar, and the `AssetsToolbar` is in a new panel at the bottom of the screen. This aligns with your request for a more organized layout.