### PR TITLE
feat: Ignore /projects directory in Vite watcher

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,12 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  server: {
+    watch: {
+      ignored: ['/projects/**'],
+    },
+  },
+});


### PR DESCRIPTION
This change prevents Vite from reloading when files inside the /projects directory are modified.