### PR TITLE
Fix: Correctly parse asset and scene lists

### DIFF
--- a/src/components/AssetsToolbar.tsx
+++ b/src/components/AssetsToolbar.tsx
@@ -9,7 +9,7 @@ const AssetsToolbar = () => {
     if (project) {
       fetch(`http://localhost:3001/api/projects/${project.name}/assets`)
         .then((res) => res.json())
-        .then((data) => setAssets(data.assets))
+        .then((data) => setAssets(data))
         .catch((err) => console.error('Failed to fetch assets:', err));
     }
   }, [project]);

--- a/src/components/SceneToolbar.tsx
+++ b/src/components/SceneToolbar.tsx
@@ -9,7 +9,7 @@ const SceneToolbar = () => {
     if (project) {
       fetch(`http://localhost:3001/api/projects/${project.name}/scenes`)
         .then((res) => res.json())
-        .then((data) => setScenes(data.scenes))
+        .then((data) => setScenes(data))
         .catch((err) => console.error('Failed to fetch scenes:', err));
     }
   }, [project]);


### PR DESCRIPTION
The `AssetsToolbar` and `SceneToolbar` components were incorrectly trying to access `data.assets` and `data.scenes` from the server response, respectively. However, the server returns the arrays directly.

This commit fixes the issue by changing `setAssets(data.assets)` to `setAssets(data)` in `AssetsToolbar.tsx` and `setScenes(data.scenes)` to `setScenes(data)` in `SceneToolbar.tsx`.